### PR TITLE
Added support for multiple domains in one certificate

### DIFF
--- a/lib/resty/auto-ssl/ssl_providers/lets_encrypt.lua
+++ b/lib/resty/auto-ssl/ssl_providers/lets_encrypt.lua
@@ -32,7 +32,7 @@ function _M.issue_cert(auto_ssl_instance, domain)
     "--cron " ..
     "--accept-terms " ..
     "--no-lock " ..
-    "--domain " .. domain .. " " ..
+    "--domain \"" .. domain .. "\" " ..
     "--challenge http-01 " ..
     "--config " .. base_dir .. "/letsencrypt/config " ..
     "--hook " .. lua_root .. "/bin/resty-auto-ssl/letsencrypt_hooks"

--- a/lib/resty/auto-ssl/storage.lua
+++ b/lib/resty/auto-ssl/storage.lua
@@ -1,7 +1,19 @@
 local resty_random = require "resty.random"
 local str = require "resty.string"
-
 local _M = {}
+
+function string:split(delimiter)
+  local result = { }
+  local from  = 1
+  local delim_from, delim_to = string.find( self, delimiter, from  )
+  while delim_from do
+    table.insert( result, string.sub( self, from , delim_from-1 ) )
+    from  = delim_to + 1
+    delim_from, delim_to = string.find( self, delimiter, from  )
+  end
+  table.insert( result, string.sub( self, from  ) )
+  return result
+end
 
 function _M.new(options)
   assert(options)
@@ -24,6 +36,8 @@ function _M.delete_challenge(self, domain, path)
 end
 
 function _M.get_cert(self, domain)
+  -- Multiple domains can be inside the string, only check for the first one
+  domain = domain:split(" ")[1]
   local json, err = self.adapter:get(domain .. ":latest")
   if err then
     return nil, err


### PR DESCRIPTION
Dehydrated has support for multiple domains, so added it here too.
dehydrated command was called with an insecure option for domain, added quotes for that
And when fetching a cert, needed to split the multiple domains so there's no lookup on multiple domains.

I hereby grant the copyright of the changes in this pull request to the authors of this lua-resty-auto-ssl project.