### PR TITLE
Add a function for querying whether a certificate exists

### DIFF
--- a/lib/resty/auto-ssl.lua
+++ b/lib/resty/auto-ssl.lua
@@ -90,6 +90,11 @@ function _M.challenge_server(self)
   server(self)
 end
 
+function _M.has_certificate(self, domain)
+  local has_certificate = require "resty.auto-ssl.utils.has_certificate"
+  return has_certificate(self, domain)
+end
+
 function _M.hook_server(self)
   local server = require "resty.auto-ssl.servers.hook"
   server(self)

--- a/lib/resty/auto-ssl/utils/has_certificate.lua
+++ b/lib/resty/auto-ssl/utils/has_certificate.lua
@@ -1,0 +1,16 @@
+return function(auto_ssl_instance, domain, shmem_only)
+  local shmem = ngx.shared.auto_ssl:get("domain:fullchain_der:" .. domain)
+  if shmem then
+    return true
+  elseif shmem_only then
+    return false
+  end
+
+  local storage = auto_ssl_instance.storage
+  local cert = storage:get_cert(domain)
+  if cert then
+    return true
+  end
+
+  return false
+end


### PR DESCRIPTION
We're using this to opportunistically redirect to https in the openresty proxy like so:

```
rewrite_by_lua_block {
  local has_cert = auto_ssl:has_certificate(ngx.var.host)
  if has_cert then
    local https_uri = "https://" .. ngx.var.host .. ngx.var.request_uri
    ngx.redirect(https_uri, 301)
  end
}
```

_Note: This would still need updates to the Readme etc, but posting for any immediate feedback._