### PR TITLE
init_master.lua: check for find

### DIFF
--- a/lib/resty/auto-ssl/init_master.lua
+++ b/lib/resty/auto-ssl/init_master.lua
@@ -5,9 +5,11 @@ local str = require "resty.string"
 
 local function check_dependencies()
   local runtime_dependencies = {
+    "awk",
     "bash",
     "curl",
     "diff",
+    "find",
     "grep",
     "mktemp",
     "openssl",


### PR DESCRIPTION
start_sockproc requires find:
```
bin/resty-auto-ssl/.start_sockproc-wrapped: line 31: find: command not found
```

Also check for it.